### PR TITLE
feat: implement Phase 2 API coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-#### Info API
+#### Info API (Phase 1)
 - `meta_and_asset_ctxs()` - Get perpetual metadata with asset contexts
 - `frontend_open_orders(user)` - Get open orders with extra frontend metadata
 - `user_fills_by_time(user, start, end, aggregate)` - Get fills within a time range
@@ -18,25 +18,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `user_rate_limit(user)` - Get API rate limit configuration
 - `user_vault_equities(user)` - Get vault equity positions
 
-#### Exchange API
+#### Info API (Phase 2)
+- `portfolio(user)` - Get comprehensive portfolio performance data
+- `user_non_funding_ledger_updates(user, start, end)` - Get ledger activity (deposits, withdrawals, transfers)
+- `extra_agents(user)` - Get list of additional authorized agents
+- `user_role(user)` - Get user role and account type information
+- `token_details(token_id)` - Get detailed token information
+
+#### Exchange API (Phase 1)
 - `schedule_cancel(time)` - Schedule automatic order cancellation
 - `create_sub_account(name)` - Create a sub-account
 - `sub_account_transfer(sub_account, is_deposit, usd)` - Transfer USD to/from sub-account
 - `sub_account_spot_transfer(sub_account, is_deposit, token, amount)` - Transfer spot tokens to/from sub-account
 - `usd_class_transfer(amount, to_perp)` - Transfer USD between perp and spot classes
 
-#### WebSocket
+#### Exchange API (Phase 2)
+- `twap_order(asset, is_buy, sz, reduce_only, duration, randomize)` - Place a TWAP order
+- `twap_cancel(asset, twap_id)` - Cancel a TWAP order
+- `convert_to_multi_sig_user(users, threshold)` - Convert account to multi-sig
+- `multi_sig(user, action, signatures)` - Execute a multi-sig transaction
+- `agent_enable_dex_abstraction()` - Enable DEX abstraction for agent
+
+#### WebSocket (Phase 1)
 - `subscribe_bbo(coin)` - Subscribe to best bid/offer updates
 - `subscribe_open_orders(user)` - Subscribe to real-time open orders
 - `subscribe_clearinghouse_state(user)` - Subscribe to real-time clearinghouse state
+
+#### WebSocket (Phase 2)
+- `subscribe_web_data3(user)` - Subscribe to aggregate user information (newer version)
+- `subscribe_twap_states(user)` - Subscribe to TWAP order states
+- `subscribe_active_asset_ctx(coin)` - Subscribe to active asset context updates
+- `subscribe_active_asset_data(user, coin)` - Subscribe to active asset data (perps)
+- `subscribe_user_twap_slice_fills(user)` - Subscribe to TWAP slice fills
+- `subscribe_user_twap_history(user)` - Subscribe to TWAP order history
 
 #### Documentation
 - Created `docs/API_AUDIT.md` with comprehensive API coverage analysis
 - Documented Phase 2 and Phase 3 implementation plans for future work
 - Updated README with fork attribution to ControlCplusControlV/ferrofluid and new package name ([#2](https://github.com/lhermoso/hyperliquid-rust-sdk/pull/2))
+- Updated API_AUDIT.md to reflect Phase 2 completion status
 
 ### Changed
 - Added `Clone` derive to `MarginSummary` type
+- Added `Clone` derive to `EvmContract` type
 
 ## [0.1.1] - 2024-XX-XX
 

--- a/docs/API_AUDIT.md
+++ b/docs/API_AUDIT.md
@@ -14,9 +14,9 @@ This document provides a comprehensive audit of the ferrofluid Rust SDK implemen
 
 | Category | Implemented | Missing | Coverage |
 |----------|-------------|---------|----------|
-| Exchange API | 15 | 25+ | ~40% |
-| Info API | 16 | 21 | ~43% |
-| WebSocket | 11 | 9 | ~55% |
+| Exchange API | 20 | 20+ | ~50% |
+| Info API | 21 | 16 | ~57% |
+| WebSocket | 17 | 3 | ~85% |
 
 ---
 
@@ -51,15 +51,15 @@ This document provides a comprehensive audit of the ferrofluid Rust SDK implemen
 | `subAccountSpotTransfer` | Transfer spot tokens between sub-accounts | `subAccountUser: Address, isDeposit: bool, token: String, amount: String` | TODO |
 | `usdClassTransfer` | Transfer USD between perp/spot classes | `amount: String, toPerp: bool` | TODO |
 
-### Phase 2 - Missing (MEDIUM PRIORITY)
+### Phase 2 - Implemented
 
-| Action | Description | Parameters |
-|--------|-------------|------------|
-| `twapOrder` | Place TWAP order | `orders: Vec<TwapOrderRequest>` |
-| `twapCancel` | Cancel TWAP order | `a: u32, t: u64` (asset, twapId) |
-| `convertToMultiSigUser` | Enable multi-sig for account | `authorizedUsers: Vec<Address>, threshold: u32` |
-| `multiSig` | Execute multi-sig transaction | `signatureChainId, payload, signatures` |
-| `agentEnableDexAbstraction` | Enable DEX abstraction for agent | `agentAddress: Address` |
+| Action | Method | File Location |
+|--------|--------|---------------|
+| `twapOrder` | `twap_order()` | `exchange.rs:869` |
+| `twapCancel` | `twap_cancel()` | `exchange.rs:894` |
+| `convertToMultiSigUser` | `convert_to_multi_sig_user()` | `exchange.rs:909` |
+| `multiSig` | `multi_sig()` | `exchange.rs:949` |
+| `agentEnableDexAbstraction` | `agent_enable_dex_abstraction()` | `exchange.rs:999` |
 
 ### Phase 3 - Missing (LOW PRIORITY)
 
@@ -136,15 +136,15 @@ This document provides a comprehensive audit of the ferrofluid Rust SDK implemen
 | `userRateLimit` | API rate limit configuration | `user: Address` | `UserRateLimit` |
 | `userVaultEquities` | Vault equity positions | `user: Address` | `Vec<VaultEquity>` |
 
-### Phase 2 - Missing (MEDIUM PRIORITY)
+### Phase 2 - Implemented
 
-| Query Type | Description | Parameters |
-|------------|-------------|------------|
-| `portfolio` | Comprehensive portfolio performance | `user: Address` |
-| `userNonFundingLedgerUpdates` | Ledger activity (deposits, withdrawals) | `user, startTime, endTime?` |
-| `extraAgents` | Additional authorized agents | `user: Address` |
-| `userRole` | User role and account type | `user: Address` |
-| `tokenDetails` | Token information | `tokenId: String` |
+| Query Type | Method | File Location |
+|------------|--------|---------------|
+| `portfolio` | `portfolio()` | `info.rs:402` |
+| `userNonFundingLedgerUpdates` | `user_non_funding_ledger_updates()` | `info.rs:415` |
+| `extraAgents` | `extra_agents()` | `info.rs:435` |
+| `userRole` | `user_role()` | `info.rs:449` |
+| `tokenDetails` | `token_details()` | `info.rs:460` |
 
 ### Phase 3 - Missing (LOW PRIORITY)
 
@@ -199,16 +199,16 @@ This document provides a comprehensive audit of the ferrofluid Rust SDK implemen
 | `openOrders` | Real-time open orders | `user: Address` |
 | `clearinghouseState` | Real-time clearinghouse data | `user: Address` |
 
-### Phase 2 - Missing (MEDIUM PRIORITY)
+### Phase 2 - Implemented
 
-| Channel | Description | Parameters |
-|---------|-------------|------------|
-| `webData3` | Aggregate user info (newer version) | `user: Address` |
-| `twapStates` | TWAP order states | `user: Address` |
-| `activeAssetCtx` | Active asset context | `coin: String` |
-| `activeAssetData` | Active perp asset data | `coin: String` |
-| `userTwapSliceFills` | TWAP slice fills | `user: Address` |
-| `userTwapHistory` | TWAP history | `user: Address` |
+| Channel | Method | File Location |
+|---------|--------|---------------|
+| `webData3` | `subscribe_web_data3()` | `websocket.rs:205` |
+| `twapStates` | `subscribe_twap_states()` | `websocket.rs:214` |
+| `activeAssetCtx` | `subscribe_active_asset_ctx()` | `websocket.rs:223` |
+| `activeAssetData` | `subscribe_active_asset_data()` | `websocket.rs:235` |
+| `userTwapSliceFills` | `subscribe_user_twap_slice_fills()` | `websocket.rs:249` |
+| `userTwapHistory` | `subscribe_user_twap_history()` | `websocket.rs:258` |
 
 ---
 
@@ -293,25 +293,40 @@ pub async fn subscribe_new_channel(
 
 ## Changelog
 
-### Phase 1 (Current Implementation)
-- [ ] Added `metaAndAssetCtxs` Info query
-- [ ] Added `frontendOpenOrders` Info query
-- [ ] Added `userFillsByTime` Info query
-- [ ] Added `historicalOrders` Info query
-- [ ] Added `subAccounts` Info query
-- [ ] Added `userRateLimit` Info query
-- [ ] Added `userVaultEquities` Info query
-- [ ] Added `scheduleCancel` Exchange action
-- [ ] Added `createSubAccount` Exchange action
-- [ ] Added `subAccountTransfer` Exchange action
-- [ ] Added `subAccountSpotTransfer` Exchange action
-- [ ] Added `usdClassTransfer` Exchange action
-- [ ] Added `bbo` WebSocket subscription
-- [ ] Added `openOrders` WebSocket subscription
-- [ ] Added `clearinghouseState` WebSocket subscription
+### Phase 1 (Implemented)
+- [x] Added `metaAndAssetCtxs` Info query
+- [x] Added `frontendOpenOrders` Info query
+- [x] Added `userFillsByTime` Info query
+- [x] Added `historicalOrders` Info query
+- [x] Added `subAccounts` Info query
+- [x] Added `userRateLimit` Info query
+- [x] Added `userVaultEquities` Info query
+- [x] Added `scheduleCancel` Exchange action
+- [x] Added `createSubAccount` Exchange action
+- [x] Added `subAccountTransfer` Exchange action
+- [x] Added `subAccountSpotTransfer` Exchange action
+- [x] Added `usdClassTransfer` Exchange action
+- [x] Added `bbo` WebSocket subscription
+- [x] Added `openOrders` WebSocket subscription
+- [x] Added `clearinghouseState` WebSocket subscription
 
-### Phase 2 (Future)
-- See sections marked as Phase 2 above
+### Phase 2 (Implemented)
+- [x] Added `portfolio` Info query
+- [x] Added `userNonFundingLedgerUpdates` Info query
+- [x] Added `extraAgents` Info query
+- [x] Added `userRole` Info query
+- [x] Added `tokenDetails` Info query
+- [x] Added `twapOrder` Exchange action
+- [x] Added `twapCancel` Exchange action
+- [x] Added `convertToMultiSigUser` Exchange action
+- [x] Added `multiSig` Exchange action
+- [x] Added `agentEnableDexAbstraction` Exchange action
+- [x] Added `webData3` WebSocket subscription
+- [x] Added `twapStates` WebSocket subscription
+- [x] Added `activeAssetCtx` WebSocket subscription
+- [x] Added `activeAssetData` WebSocket subscription
+- [x] Added `userTwapSliceFills` WebSocket subscription
+- [x] Added `userTwapHistory` WebSocket subscription
 
 ### Phase 3 (Future)
 - See sections marked as Phase 3 above

--- a/src/providers/websocket.rs
+++ b/src/providers/websocket.rs
@@ -199,6 +199,70 @@ impl RawWsProvider {
         self.subscribe(subscription).await
     }
 
+    // ==================== Phase 2 New Subscriptions ====================
+
+    /// Subscribe to aggregate user information (newer version of webData2)
+    pub async fn subscribe_web_data3(
+        &mut self,
+        user: Address,
+    ) -> Result<(SubscriptionId, UnboundedReceiver<Message>), HyperliquidError> {
+        let subscription = Subscription::WebData3 { user };
+        self.subscribe(subscription).await
+    }
+
+    /// Subscribe to TWAP order states for a user
+    pub async fn subscribe_twap_states(
+        &mut self,
+        user: Address,
+    ) -> Result<(SubscriptionId, UnboundedReceiver<Message>), HyperliquidError> {
+        let subscription = Subscription::TwapStates { user };
+        self.subscribe(subscription).await
+    }
+
+    /// Subscribe to active asset context updates
+    pub async fn subscribe_active_asset_ctx(
+        &mut self,
+        coin: impl Into<Symbol>,
+    ) -> Result<(SubscriptionId, UnboundedReceiver<Message>), HyperliquidError> {
+        let symbol = coin.into();
+        let subscription = Subscription::ActiveAssetCtx {
+            coin: symbol.as_str().to_string(),
+        };
+        self.subscribe(subscription).await
+    }
+
+    /// Subscribe to active asset data for a user and coin (perps only)
+    pub async fn subscribe_active_asset_data(
+        &mut self,
+        user: Address,
+        coin: impl Into<Symbol>,
+    ) -> Result<(SubscriptionId, UnboundedReceiver<Message>), HyperliquidError> {
+        let symbol = coin.into();
+        let subscription = Subscription::ActiveAssetData {
+            user,
+            coin: symbol.as_str().to_string(),
+        };
+        self.subscribe(subscription).await
+    }
+
+    /// Subscribe to TWAP slice fills for a user
+    pub async fn subscribe_user_twap_slice_fills(
+        &mut self,
+        user: Address,
+    ) -> Result<(SubscriptionId, UnboundedReceiver<Message>), HyperliquidError> {
+        let subscription = Subscription::UserTwapSliceFills { user };
+        self.subscribe(subscription).await
+    }
+
+    /// Subscribe to TWAP order history for a user
+    pub async fn subscribe_user_twap_history(
+        &mut self,
+        user: Address,
+    ) -> Result<(SubscriptionId, UnboundedReceiver<Message>), HyperliquidError> {
+        let subscription = Subscription::UserTwapHistory { user };
+        self.subscribe(subscription).await
+    }
+
     /// Generic subscription method
     pub async fn subscribe(
         &mut self,
@@ -523,6 +587,70 @@ impl ManagedWsProvider {
         user: Address,
     ) -> Result<(SubscriptionId, UnboundedReceiver<Message>), HyperliquidError> {
         let subscription = Subscription::ClearinghouseState { user };
+        self.subscribe(subscription).await
+    }
+
+    // ==================== Phase 2 New Subscriptions ====================
+
+    /// Subscribe to aggregate user information (newer version) with automatic replay on reconnect
+    pub async fn subscribe_web_data3(
+        &self,
+        user: Address,
+    ) -> Result<(SubscriptionId, UnboundedReceiver<Message>), HyperliquidError> {
+        let subscription = Subscription::WebData3 { user };
+        self.subscribe(subscription).await
+    }
+
+    /// Subscribe to TWAP order states with automatic replay on reconnect
+    pub async fn subscribe_twap_states(
+        &self,
+        user: Address,
+    ) -> Result<(SubscriptionId, UnboundedReceiver<Message>), HyperliquidError> {
+        let subscription = Subscription::TwapStates { user };
+        self.subscribe(subscription).await
+    }
+
+    /// Subscribe to active asset context updates with automatic replay on reconnect
+    pub async fn subscribe_active_asset_ctx(
+        &self,
+        coin: impl Into<Symbol>,
+    ) -> Result<(SubscriptionId, UnboundedReceiver<Message>), HyperliquidError> {
+        let symbol = coin.into();
+        let subscription = Subscription::ActiveAssetCtx {
+            coin: symbol.as_str().to_string(),
+        };
+        self.subscribe(subscription).await
+    }
+
+    /// Subscribe to active asset data with automatic replay on reconnect
+    pub async fn subscribe_active_asset_data(
+        &self,
+        user: Address,
+        coin: impl Into<Symbol>,
+    ) -> Result<(SubscriptionId, UnboundedReceiver<Message>), HyperliquidError> {
+        let symbol = coin.into();
+        let subscription = Subscription::ActiveAssetData {
+            user,
+            coin: symbol.as_str().to_string(),
+        };
+        self.subscribe(subscription).await
+    }
+
+    /// Subscribe to TWAP slice fills with automatic replay on reconnect
+    pub async fn subscribe_user_twap_slice_fills(
+        &self,
+        user: Address,
+    ) -> Result<(SubscriptionId, UnboundedReceiver<Message>), HyperliquidError> {
+        let subscription = Subscription::UserTwapSliceFills { user };
+        self.subscribe(subscription).await
+    }
+
+    /// Subscribe to TWAP order history with automatic replay on reconnect
+    pub async fn subscribe_user_twap_history(
+        &self,
+        user: Address,
+    ) -> Result<(SubscriptionId, UnboundedReceiver<Message>), HyperliquidError> {
+        let subscription = Subscription::UserTwapHistory { user };
         self.subscribe(subscription).await
     }
 

--- a/src/types/info_types.rs
+++ b/src/types/info_types.rs
@@ -353,7 +353,7 @@ pub struct SpotPairMeta {
     pub is_canonical: bool,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(untagged)]
 pub enum EvmContract {
     String(String),
@@ -516,4 +516,167 @@ pub struct UserRateLimit {
 pub struct VaultEquity {
     pub vault_address: Address,
     pub equity: String,
+}
+
+// ==================== Phase 2 New Types ====================
+
+/// Response for portfolio - comprehensive portfolio performance data
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Portfolio {
+    /// Account value in USD
+    pub account_value: String,
+    /// Total notional position value
+    pub total_ntl_pos: String,
+    /// Total margin used
+    pub total_margin_used: String,
+    /// Total raw USD
+    pub total_raw_usd: String,
+    /// Withdrawable amount
+    pub withdrawable: String,
+    /// Cumulative PnL
+    #[serde(default)]
+    pub cum_pnl: Option<String>,
+    /// Cumulative funding
+    #[serde(default)]
+    pub cum_funding: Option<String>,
+    /// Cumulative volume
+    #[serde(default)]
+    pub cum_vlm: Option<String>,
+}
+
+/// Response for userNonFundingLedgerUpdates - ledger activity
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct NonFundingLedgerUpdate {
+    pub time: u64,
+    pub hash: String,
+    pub delta: NonFundingDelta,
+}
+
+/// Delta type for non-funding ledger updates
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum NonFundingDelta {
+    /// Deposit to account
+    Deposit { usdc: String },
+    /// Withdrawal from account
+    Withdraw {
+        usdc: String,
+        nonce: u64,
+        fee: String,
+    },
+    /// Internal transfer between accounts
+    InternalTransfer {
+        usdc: String,
+        user: Address,
+        destination: Address,
+        fee: String,
+    },
+    /// Sub-account transfer
+    SubAccountTransfer {
+        usdc: String,
+        user: Address,
+        destination: Address,
+    },
+    /// Spot token transfer
+    SpotTransfer {
+        token: String,
+        amount: String,
+        user: Address,
+        destination: Address,
+        fee: String,
+    },
+    /// Liquidation
+    Liquidation {
+        liquidated_user: Address,
+        #[serde(default)]
+        leveraged_ntl: Option<String>,
+    },
+    /// Account class transfer (perp <-> spot)
+    AccountClassTransfer { usdc: String, to_perp: bool },
+    /// Spot genesis
+    SpotGenesis { token: String, amount: String },
+    /// Rewards claim
+    RewardsClaim { amount: String },
+    /// Vault deposit
+    VaultDeposit { vault: Address, usdc: String },
+    /// Vault withdrawal
+    VaultWithdraw {
+        vault: Address,
+        usdc: String,
+        #[serde(default)]
+        fee: Option<String>,
+    },
+    /// Vault leader commission
+    VaultLeaderCommission { usdc: String },
+}
+
+/// Response for extraAgents - list of additional authorized agents
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ExtraAgent {
+    pub address: Address,
+    pub name: Option<String>,
+    #[serde(default)]
+    pub valid_until: Option<u64>,
+}
+
+/// Response for userRole - user role and account type
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct UserRole {
+    /// Role type (e.g., "user", "vault", "subAccount")
+    pub role: String,
+    /// Additional role data
+    #[serde(default)]
+    pub data: Option<UserRoleData>,
+}
+
+/// Additional data for user role
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct UserRoleData {
+    /// Master account for sub-accounts
+    #[serde(default)]
+    pub master: Option<Address>,
+    /// Vault address for vault accounts
+    #[serde(default)]
+    pub vault: Option<Address>,
+}
+
+/// Response for tokenDetails - detailed token information
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct TokenDetails {
+    /// Token name/symbol
+    pub name: String,
+    /// Size decimals for trading
+    pub sz_decimals: u32,
+    /// Wei decimals for on-chain representation
+    pub wei_decimals: u32,
+    /// Token index
+    pub index: u32,
+    /// Token ID (hex string)
+    pub token_id: String,
+    /// Whether this is a canonical token
+    pub is_canonical: bool,
+    /// Full name of the token
+    #[serde(default)]
+    pub full_name: Option<String>,
+    /// EVM contract information
+    #[serde(default)]
+    pub evm_contract: Option<EvmContract>,
+    /// Deployer trading fee share
+    #[serde(default)]
+    pub deployer_trading_fee_share: Option<String>,
+    /// Total supply
+    #[serde(default)]
+    pub total_supply: Option<String>,
+    /// Circulating supply
+    #[serde(default)]
+    pub circulating_supply: Option<String>,
+    /// Market cap
+    #[serde(default)]
+    pub market_cap: Option<String>,
 }


### PR DESCRIPTION
## Summary

This PR implements Phase 2 of the API coverage as documented in `docs/API_AUDIT.md`. It adds 16 new endpoints/subscriptions across Info API, Exchange API, and WebSocket subscriptions.

### Info API (5 endpoints)
- `portfolio()` - Get comprehensive portfolio performance data
- `user_non_funding_ledger_updates()` - Get ledger activity (deposits, withdrawals, transfers)
- `extra_agents()` - Get list of additional authorized agents
- `user_role()` - Get user role and account type information
- `token_details()` - Get detailed token information

### Exchange API (5 actions)
- `twap_order()` - Place TWAP (Time-Weighted Average Price) orders
- `twap_cancel()` - Cancel TWAP orders
- `convert_to_multi_sig_user()` - Convert account to multi-sig mode
- `multi_sig()` - Execute multi-sig transactions
- `agent_enable_dex_abstraction()` - Enable DEX abstraction for agent

### WebSocket (6 subscriptions)
- `subscribe_web_data3()` - Aggregate user info (newer version)
- `subscribe_twap_states()` - TWAP order states
- `subscribe_active_asset_ctx()` - Active asset context updates
- `subscribe_active_asset_data()` - Active asset data (perps only)
- `subscribe_user_twap_slice_fills()` - TWAP slice execution fills
- `subscribe_user_twap_history()` - TWAP order history

## Changes
- Added response types for 5 new Info queries in `src/types/info_types.rs`
- Added 5 new Info API methods in `src/providers/info.rs`
- Added action types for 5 new Exchange actions in `src/types/actions.rs`
- Added 5 new Exchange API methods in `src/providers/exchange.rs`
- Added message types for 6 new WebSocket subscriptions in `src/types/ws.rs`
- Added 6 new WebSocket subscription methods in `src/providers/websocket.rs`
- Updated `docs/API_AUDIT.md` to mark Phase 2 as complete
- Updated `CHANGELOG.md` with new endpoints

## Test Plan
- [x] `cargo build` compiles successfully
- [x] `cargo test --lib` passes all 19 library tests
- [x] `cargo clippy --lib` passes with no new warnings
- [x] `cargo fmt` applied

Fixes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)