### PR TITLE
fix(types): align Portfolio and SpotMetaAndAssetCtxs with API response format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `Clone` derive to `MarginSummary` type
 - Added `Clone` derive to `EvmContract` type
 - Aligned library import name with crate name - now import as `hyperliquid_rust_sdk` instead of `ferrofluid` ([#10](https://github.com/lhermoso/hyperliquid-rust-sdk/pull/10))
+- **BREAKING**: `Portfolio` type changed from a struct to `Vec<(String, PortfolioPeriodData)>` to match actual API response format which returns time-series data per period (day, week, month, allTime, etc.)
+- **BREAKING**: `SpotMetaAndAssetCtxs` type restructured to correctly deserialize the API's `[{universe, tokens}, [...assetCtxs]]` tuple format; now has `meta: SpotMeta` and `asset_ctxs: Vec<SpotAssetContext>` fields
+- Added `Clone` derive to `SpotMeta`, `SpotPairMeta`, and `TokenMeta` types
+
+### Fixed
+- Fixed `portfolio(user)` endpoint deserialization - API returns array of time period tuples, not a flat object
+- Fixed `spot_meta_and_asset_ctxs()` endpoint deserialization - API returns a 2-element tuple array, not a single object with all fields
 
 ## [0.1.1] - 2024-XX-XX
 

--- a/examples/02_info_provider.rs
+++ b/examples/02_info_provider.rs
@@ -198,12 +198,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("\n=== Testing portfolio endpoint ===");
     match info.portfolio(user).await {
         Ok(portfolio) => {
-            println!("Portfolio data retrieved:");
-            println!("  Account Value: {}", portfolio.account_value);
-            println!("  Total Ntl Pos: {}", portfolio.total_ntl_pos);
-            println!("  Total Margin Used: {}", portfolio.total_margin_used);
-            println!("  Withdrawable: {}", portfolio.withdrawable);
-            println!("  Cum PnL: {:?}", portfolio.cum_pnl);
+            println!("Portfolio data retrieved ({} time periods):", portfolio.len());
+            for (period, data) in portfolio.iter().take(3) {
+                println!("  Period: {}", period);
+                println!("    Volume: {}", data.vlm);
+                println!(
+                    "    Account Value History: {} entries",
+                    data.account_value_history.len()
+                );
+                println!("    PnL History: {} entries", data.pnl_history.len());
+            }
         }
         Err(e) => println!(
             "Error fetching portfolio (expected if user doesn't exist): {}",


### PR DESCRIPTION
## Summary

Fixes SDK type definitions for `portfolio()` and `spot_meta_and_asset_ctxs()` endpoints to match the actual JSON structure returned by the Hyperliquid API.

- **Portfolio**: Changed from a flat struct to `Vec<(String, PortfolioPeriodData)>` to match the API's array-of-tuples format with time periods (day, week, month, allTime, perpDay, perpWeek, perpMonth, perpAllTime)
- **SpotMetaAndAssetCtxs**: Restructured to correctly deserialize the API's `[{universe, tokens}, [...assetCtxs]]` tuple format
- Added new `SpotAssetContext` type with spot-specific fields
- Added `Clone` derive to `SpotMeta`, `SpotPairMeta`, `TokenMeta` for consistency

## Breaking Changes

- `Portfolio` type is now `Vec<(String, PortfolioPeriodData)>` instead of a struct with account value fields
- `SpotMetaAndAssetCtxs` now has `meta: SpotMeta` and `asset_ctxs: Vec<SpotAssetContext>` fields

## Test plan

- [x] `cargo test --test info_provider_test` passes (24 tests)
- [x] `cargo build --examples` compiles successfully
- [x] Live API tests verify deserialization works correctly

Fixes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)