### PR TITLE
fix(exchange): use EIP-712 user signing for usd_class_transfer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed unused `created_at` field from `ManagedSubscription` struct in websocket provider ([#33](https://github.com/lhermoso/hyperliquid-rust-sdk/pull/33))
 
 ### Fixed
+- Fixed `usd_class_transfer` using wrong signing method (L1 signing instead of EIP-712 user signing), missing required fields (`hyperliquidChain`, `signatureChainId`, `nonce`), and incorrectly including `vaultAddress` in the payload ([#40](https://github.com/lhermoso/hyperliquid-rust-sdk/issues/40))
 - Fixed doc tests in `symbols.rs` that used incorrect crate name `ferrofluid` instead of `hyperliquid_rust_sdk` ([#23](https://github.com/lhermoso/hyperliquid-rust-sdk/pull/23))
 - Fixed `portfolio(user)` endpoint deserialization - API returns array of time period tuples, not a flat object
 - Fixed `spot_meta_and_asset_ctxs()` endpoint deserialization - API returns a 2-element tuple array, not a single object with all fields

--- a/src/providers/exchange/mod.rs
+++ b/src/providers/exchange/mod.rs
@@ -956,11 +956,22 @@ impl<S: HyperliquidSigner> RawExchangeProvider<S> {
         amount: &str,
         to_perp: bool,
     ) -> Result<ExchangeResponseStatus> {
+        let (chain_id, _) = self.infer_network();
+        let chain = if chain_id == CHAIN_ID_MAINNET {
+            "Mainnet"
+        } else {
+            "Testnet"
+        };
+
         let action = UsdClassTransfer {
+            signature_chain_id: chain_id,
+            hyperliquid_chain: chain.to_string(),
             amount: amount.to_string(),
             to_perp,
+            nonce: Self::current_nonce(),
         };
-        self.send_l1_action("usdClassTransfer", &action).await
+
+        self.send_user_action(&action).await
     }
 
     // ==================== Phase 2 New Actions ====================
@@ -1093,7 +1104,7 @@ impl<S: HyperliquidSigner> RawExchangeProvider<S> {
             v: 27,
         };
 
-        self.post(action_with_type, signature, nonce).await
+        self.post(action_with_type, signature, nonce, true).await
     }
 
     /// Enable DEX abstraction for the current agent.
@@ -1655,7 +1666,7 @@ impl<S: HyperliquidSigner> RawExchangeProvider<S> {
             action_value
         };
 
-        self.post(final_action, signature, nonce).await
+        self.post(final_action, signature, nonce, true).await
     }
 
     async fn send_user_action<T: HyperliquidAction + Serialize>(
@@ -1688,6 +1699,7 @@ impl<S: HyperliquidSigner> RawExchangeProvider<S> {
             "Withdraw" => "withdraw3",
             "SpotSend" => "spotSend",
             "ApproveBuilderFee" => "approveBuilderFee",
+            "UsdClassTransfer" => "usdClassTransfer",
             _ => action_type,
         };
 
@@ -1697,7 +1709,8 @@ impl<S: HyperliquidSigner> RawExchangeProvider<S> {
         }
 
         // Send directly without L1 wrapping for user actions
-        self.post(action_value, signature, nonce).await
+        // User-signed actions do not include vaultAddress in the payload
+        self.post(action_value, signature, nonce, false).await
     }
 
     async fn post(
@@ -1705,10 +1718,11 @@ impl<S: HyperliquidSigner> RawExchangeProvider<S> {
         action: Value,
         signature: HyperliquidSignature,
         nonce: u64,
+        include_vault_address: bool,
     ) -> Result<ExchangeResponseStatus> {
         // Hyperliquid expects signature as an object with r, s, v fields
         // not as a concatenated hex string
-        let payload = json!({
+        let mut payload = json!({
             "action": action,
             "signature": {
                 "r": format!("0x{:064x}", signature.r),
@@ -1716,8 +1730,19 @@ impl<S: HyperliquidSigner> RawExchangeProvider<S> {
                 "v": signature.v,
             },
             "nonce": nonce,
-            "vaultAddress": self.vault_address,
         });
+
+        // Only include vaultAddress for L1/agent actions (orders, cancels, etc.)
+        // User-signed actions (usdClassTransfer, usdSend, withdraw, etc.) must not include it
+        if include_vault_address {
+            if let Value::Object(ref mut map) = payload {
+                map.insert(
+                    "vaultAddress".to_string(),
+                    serde_json::to_value(&self.vault_address)
+                        .unwrap_or(Value::Null),
+                );
+            }
+        }
 
         let body = Full::new(Bytes::from(serde_json::to_vec(&payload)?));
         let request = Request::builder()

--- a/src/types/actions.rs
+++ b/src/types/actions.rs
@@ -321,8 +321,34 @@ pub struct SubAccountSpotTransfer {
 #[derive(Debug, Clone, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UsdClassTransfer {
+    #[serde(serialize_with = "serialize_chain_id")]
+    pub signature_chain_id: u64,
+    pub hyperliquid_chain: String,
     pub amount: String,
     pub to_perp: bool,
+    pub nonce: u64,
+}
+
+impl crate::types::eip712::HyperliquidAction for UsdClassTransfer {
+    const TYPE_STRING: &'static str =
+        "UsdClassTransfer(string hyperliquidChain,string amount,bool toPerp,uint64 nonce)";
+    const USE_PREFIX: bool = true;
+
+    fn chain_id(&self) -> Option<u64> {
+        Some(self.signature_chain_id)
+    }
+
+    fn encode_data(&self) -> Vec<u8> {
+        use crate::types::eip712::encode_value;
+        let mut encoded = Vec::new();
+        encoded.extend_from_slice(&Self::type_hash()[..]);
+        encoded.extend_from_slice(&encode_value(&self.hyperliquid_chain)[..]);
+        encoded.extend_from_slice(&encode_value(&self.amount)[..]);
+        // bool is encoded as uint256 (0 or 1)
+        encoded.extend_from_slice(&encode_value(&(self.to_perp as u64))[..]);
+        encoded.extend_from_slice(&encode_value(&self.nonce)[..]);
+        encoded
+    }
 }
 
 // ==================== Phase 2 New Actions ====================


### PR DESCRIPTION
## Summary

Fixes #40 - `usd_class_transfer` returns HTTP 422 due to three compounding issues: wrong signing method, missing fields, and unsupported `vaultAddress` in the payload.

### Changes

**Bug 1 - Wrong signing method**: Switched `usd_class_transfer` from `send_l1_action` (Agent/L1 signing) to `send_user_action` (EIP-712 user signing), matching the API's expectation of `HyperliquidTransaction:UsdClassTransfer` typed data.

**Bug 2 - Missing fields in action struct**: Added `hyperliquid_chain`, `signature_chain_id`, and `nonce` fields to the `UsdClassTransfer` struct, and implemented the `HyperliquidAction` trait with proper `encode_data` for EIP-712 struct hashing. Follows the same pattern as `UsdSend`, `Withdraw`, and `SpotSend`.

**Bug 3 - vaultAddress sent when it shouldn't be**: Modified the `post()` method to accept an `include_vault_address` parameter. L1/agent actions (`send_l1_action`, `multi_sig`) pass `true`, while user-signed actions (`send_user_action`) pass `false`, ensuring `vaultAddress` is excluded from the payload for `usdClassTransfer` and other user-signed actions.

### Files Changed

- `src/types/actions.rs` - Updated `UsdClassTransfer` struct with new fields and `HyperliquidAction` impl
- `src/providers/exchange/mod.rs` - Updated `usd_class_transfer()`, `send_user_action()`, and `post()` methods
- `CHANGELOG.md` - Documented the fix

### Testing

- All 210 existing tests pass
- No regressions to other exchange actions